### PR TITLE
chore/use-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "firebase": "^9.9.2",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",
@@ -31,6 +32,7 @@
     "@vitejs/plugin-react": "^1.3.0",
     "babel-loader": "^8.2.5",
     "typescript": "^4.6.3",
-    "vite": "^2.9.9"
+    "vite": "^2.9.9",
+    "vite-tsconfig-paths": "^3.5.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,106 +1,16 @@
-import { useState, useEffect } from "react";
-import logo from "./logo.svg";
-import "./App.css";
-import "./firebaseApp";
-import {
-  getAuth,
-  Auth,
-  GithubAuthProvider,
-  signInWithPopup,
-} from "firebase/auth";
+import { BrowserRouter, useRoutes } from "react-router-dom";
+import { Home } from "router/pages/Home";
 
-const OWNER = "tofuchic";
-const REPO = "scoooool";
+const RootRoutes = () => {
+  return useRoutes([{ path: "/", element: <Home /> }]);
+};
 
-function App() {
-  const [token, setToken] = useState<string | null>(null);
-  const [auth, setAuth] = useState<Auth | null>(null);
-  const [provider, setProvider] = useState<GithubAuthProvider | null>(null);
-
-  // GitHub OAuth Provider ObjectのInstanceを作成
-  useEffect(() => {
-    if (provider === null) {
-      const newProvider = new GithubAuthProvider();
-      newProvider.addScope("repo"); // 既定ではユーザー自身のemailを取得するスコープしか付与されない。必要に応じてスコープを追加する
-      setProvider(newProvider);
-    }
-  }, [provider]);
-
-  // Firebase Appに対するAuth instanceを取得
-  useEffect(() => {
-    if (provider !== null && auth === null) {
-      setAuth(getAuth());
-      console.debug(auth);
-    }
-  }, [auth, provider]);
-
-  // ポップアップによるサインインを実施し、成功したらアクセストークンを取得する
-  useEffect(() => {
-    if (provider !== null && auth !== null && token === null) {
-      signInWithPopup(auth, provider).then((result) => {
-        const credential = GithubAuthProvider.credentialFromResult(result);
-        if (credential && credential.accessToken) {
-          setToken(credential.accessToken);
-          console.debug("token: " + credential.accessToken);
-        }
-        console.debug(result.user);
-      });
-    }
-  }, [auth, provider, token]);
-
-  // アクセストークンを使用してGitHub API（GET /Issues）へリクエストする
-  useEffect(() => {
-    if (token !== null) {
-      fetch(`https://api.github.com/repos/${OWNER}/${REPO}/issues`, {
-        headers: {
-          Authorization: `token ${token}`,
-          Accept: "application / vnd.github.v3 + json",
-        },
-      }).then((result) => {
-        result.json().then((result) => {
-          console.debug(result);
-        });
-      });
-    }
-  }, [token]);
-
-  const [count, setCount] = useState(0);
-
+const App = () => {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>Hello Vite + React!</p>
-        <p>
-          <button type="button" onClick={() => setCount((count) => count + 1)}>
-            count is: {count}
-          </button>
-        </p>
-        <p>
-          Edit <code>App.tsx</code> and save to test HMR updates.
-        </p>
-        <p>
-          <a
-            className="App-link"
-            href="https://reactjs.org"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn React
-          </a>
-          {" | "}
-          <a
-            className="App-link"
-            href="https://vitejs.dev/guide/features.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Vite Docs
-          </a>
-        </p>
-      </header>
-    </div>
+    <BrowserRouter>
+      <RootRoutes />
+    </BrowserRouter>
   );
-}
+};
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "App";
+import "index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <StrictMode>
     <App />
-  </React.StrictMode>
-)
+  </StrictMode>
+);

--- a/src/router/pages/Home.tsx
+++ b/src/router/pages/Home.tsx
@@ -1,0 +1,103 @@
+import { useState, useEffect } from "react";
+import logo from "logo.svg";
+import "App.css";
+import "firebaseApp";
+import {
+  getAuth,
+  Auth,
+  GithubAuthProvider,
+  signInWithPopup,
+} from "firebase/auth";
+
+export const Home = () => {
+  const OWNER = "tofuchic";
+  const REPO = "scoooool";
+
+  const [token, setToken] = useState<string | null>(null);
+  const [auth, setAuth] = useState<Auth | null>(null);
+  const [provider, setProvider] = useState<GithubAuthProvider | null>(null);
+
+  // GitHub OAuth Provider ObjectのInstanceを作成
+  useEffect(() => {
+    if (provider === null) {
+      const newProvider = new GithubAuthProvider();
+      newProvider.addScope("repo"); // 既定ではユーザー自身のemailを取得するスコープしか付与されない。必要に応じてスコープを追加する
+      setProvider(newProvider);
+    }
+  }, [provider]);
+
+  // Firebase Appに対するAuth instanceを取得
+  useEffect(() => {
+    if (provider !== null && auth === null) {
+      setAuth(getAuth());
+      console.debug(auth);
+    }
+  }, [auth, provider]);
+
+  // ポップアップによるサインインを実施し、成功したらアクセストークンを取得する
+  useEffect(() => {
+    if (provider !== null && auth !== null && token === null) {
+      signInWithPopup(auth, provider).then((result) => {
+        const credential = GithubAuthProvider.credentialFromResult(result);
+        if (credential && credential.accessToken) {
+          setToken(credential.accessToken);
+          console.debug("token: " + credential.accessToken);
+        }
+        console.debug(result.user);
+      });
+    }
+  }, [auth, provider, token]);
+
+  // アクセストークンを使用してGitHub API（GET /Issues）へリクエストする
+  useEffect(() => {
+    if (token !== null) {
+      fetch(`https://api.github.com/repos/${OWNER}/${REPO}/issues`, {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: "application / vnd.github.v3 + json",
+        },
+      }).then((result) => {
+        result.json().then((result) => {
+          console.debug(result);
+        });
+      });
+    }
+  }, [token]);
+
+  const [count, setCount] = useState(0);
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <p>Hello Vite + React!</p>
+        <p>
+          <button type="button" onClick={() => setCount((count) => count + 1)}>
+            count is: {count}
+          </button>
+        </p>
+        <p>
+          Edit <code>App.tsx</code> and save to test HMR updates.
+        </p>
+        <p>
+          <a
+            className="App-link"
+            href="https://reactjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn React
+          </a>
+          {" | "}
+          <a
+            className="App-link"
+            href="https://vitejs.dev/guide/features.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Vite Docs
+          </a>
+        </p>
+      </header>
+    </div>
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src"
   },
-  "include": ["src"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/scoooool/",
-  plugins: [react()]
-})
+  base: "/",
+  plugins: [react(), tsconfigPaths()],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,11 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@cush/relative@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cush/relative/-/relative-1.0.0.tgz#8cd1769bf9bde3bb27dac356b1bc94af40f6cc16"
+  integrity sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==
+
 "@design-systems/utils@2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@design-systems/utils/-/utils-2.12.0.tgz#955c108be07cb8f01532207cbfea8f848fa760c9"
@@ -6268,6 +6273,11 @@ glob-promise@^4.2.0:
   dependencies:
     "@types/glob" "^7.1.3"
 
+glob-regex@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/glob-regex/-/glob-regex-0.3.2.tgz#27348f2f60648ec32a4a53137090b9fb934f3425"
+  integrity sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -6342,6 +6352,11 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -6533,6 +6548,13 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -9110,6 +9132,21 @@ react-refresh@^0.13.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz#cbd01a4482a177a5da8d44c9755ebb1f26d5a1c1"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
 
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
+
 react@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -9190,6 +9227,16 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recrawl-sync@^2.0.3:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recrawl-sync/-/recrawl-sync-2.2.2.tgz#a5a8664c77267d603d601825af544d6716d69e15"
+  integrity sha512-E2sI4F25Fu2nrfV+KsnC7/qfk/spQIYXlonfQoS4rwxeNK5BjxnLPbWiRXHVXPwYBOTWtPX5765kTm/zJiL+LQ==
+  dependencies:
+    "@cush/relative" "^1.0.0"
+    glob-regex "^0.3.0"
+    slash "^3.0.0"
+    tslib "^1.9.3"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -10032,6 +10079,11 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -10344,6 +10396,15 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tsconfig-paths@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz#f8ef7d467f08ae3a695335bf1ece088c5538d2c1"
+  integrity sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==
+  dependencies:
+    json5 "^2.2.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
@@ -10734,6 +10795,16 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vite-tsconfig-paths@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-3.5.0.tgz#bfdf93f8072eff04125112ea9602fd50ae8cdad9"
+  integrity sha512-NKIubr7gXgh/3uniQaOytSg+aKWPrjquP6anAy+zCWEn6h9fB8z2/qdlfQrTgZWaXJ2pHVlllrSdRZltHn9P4g==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    recrawl-sync "^2.0.3"
+    tsconfig-paths "^4.0.0"
 
 vite@^2.9.9:
   version "2.9.14"


### PR DESCRIPTION
- import時に相対パスを参照できるようにした
  - viteが相対パスを参照してビルドできるようにする設定 -> https://www.npmjs.com/package/vite-tsconfig-paths
  - eslintなどが相対パスを参照できるようにする設定 -> tsconfig.json
- react-router-domを導入
  - App.jsxをApp.jsxおよびHome.jsxに分離